### PR TITLE
Update yellow_shulker_box.json

### DIFF
--- a/generators/datapack/templates/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
+++ b/generators/datapack/templates/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
@@ -1,67 +1,68 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "rolls": 1,
-      "entries": [
+    "type": "minecraft:block",
+    "pools": [
         {
-          "type": "minecraft:alternatives",
-          "children": [
-            {
-              "type": "minecraft:dynamic",
-              "name": "minecraft:contents",
-              "conditions": [
+            "rolls": 1,
+            "entries": [
                 {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "nbt": "{drop_contents: 1b}"
-                  }
+                    "type": "minecraft:alternatives",
+                    "children": [
+                        {
+                            "type": "minecraft:dynamic",
+                            "name": "minecraft:contents",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:match_tool",
+                                    "predicate": {
+                                        "item": "minecraft:air",
+                                        "nbt": "{drop_contents:1b}"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "minecraft:yellow_shulker_box",
+                            "functions": [
+                                {
+                                    "function": "minecraft:copy_name",
+                                    "source": "block_entity"
+                                },
+                                {
+                                    "function": "minecraft:copy_nbt",
+                                    "source": "block_entity",
+                                    "ops": [
+                                        {
+                                            "source": "Lock",
+                                            "target": "BlockEntityTag.Lock",
+                                            "op": "replace"
+                                        },
+                                        {
+                                            "source": "LootTable",
+                                            "target": "BlockEntityTag.LootTable",
+                                            "op": "replace"
+                                        },
+                                        {
+                                            "source": "LootTableSeed",
+                                            "target": "BlockEntityTag.LootTableSeed",
+                                            "op": "replace"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "function": "minecraft:set_contents",
+                                    "entries": [
+                                        {
+                                            "type": "minecraft:dynamic",
+                                            "name": "minecraft:contents"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
                 }
-              ]
-            },
-            {
-              "type": "minecraft:item",
-              "functions": [
-                {
-                  "function": "minecraft:copy_name",
-                  "source": "block_entity"
-                },
-                {
-                  "function": "minecraft:copy_nbt",
-                  "source": "block_entity",
-                  "ops": [
-                    {
-                      "source": "Lock",
-                      "target": "BlockEntityTag.Lock",
-                      "op": "replace"
-                    },
-                    {
-                      "source": "LootTable",
-                      "target": "BlockEntityTag.LootTable",
-                      "op": "replace"
-                    },
-                    {
-                      "source": "LootTableSeed",
-                      "target": "BlockEntityTag.LootTableSeed",
-                      "op": "replace"
-                    }
-                  ]
-                },
-                {
-                  "function": "minecraft:set_contents",
-                  "entries": [
-                    {
-                      "type": "minecraft:dynamic",
-                      "name": "minecraft:contents"
-                    }
-                  ]
-                }
-              ],
-              "name": "minecraft:yellow_shulker_box"
-            }
-          ]
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
Added a test for the used item being air, as suggested by rx in this message:
https://discord.com/channels/154777837382008833/259800273445191690/851940813802045441
Additionally, it makes it follow the exact same format as the standardized yellow shulker box loot table, which shouldn't affect its functionality.